### PR TITLE
Fix multi remote error、add `git hist` and update the install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 Treat git log as a book, exec `git next` or `git prev` to checkout the next or the previous commit.
 
-### 像翻页一样跳转到上一(n)条或下一(n)条 Git 历史节点
+
+## How to install?
+
+1. Clone this repository
+2. Execute command : `./install.sh`
+
+or
+
+1. Download the `git-paging-alias.txt`
+2. Execute `git config --global --add include.path PATH/git-paging-ali.txt`
+
+## Git alias guidelines
+
+1. `git hist [<BRANCH_NAME> or <revision-range> [<options>]]` - show all history commits
+2. `git swc-first` - switch the first commit
+3. `git swc-last` - switch the last commit
+4. `git swc-prev` - switch previous commit
+5. `git swc-next` - switch next commit
+
+## 像翻页一样跳转到上一(n)条或下一(n)条 Git 历史节点
 
 请查看博客文章 [阅读开源代码小技巧](https://hutusi.com/git-paging) 获得更多使用帮助。
+

--- a/git-first
+++ b/git-first
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 first() {
-	branch=`git symbolic-ref refs/remotes/origin/HEAD`
-	git log --reverse --pretty=%H $branch | head -1 | xargs git checkout 
+    REMOTE=$(git remote)
+    branch=${1:-$(git symbolic-ref "refs/remotes/$REMOTE/HEAD")}
+    git log --reverse --pretty=%H "$branch" | head -1 | xargs git checkout
 }
 first "$@"

--- a/git-hist
+++ b/git-hist
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+hist() {
+    if test -z $1;then
+        REMOTE=$(git remote)
+        params=${1:-$(git symbolic-ref "refs/remotes/$REMOTE/HEAD")}
+    else
+        params="$@"
+    fi
+    git log --color --graph --abbrev-commit \
+        --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<author:%an == commitor:%cn>%Creset' \
+        $params
+}
+hist "$@"

--- a/git-last
+++ b/git-last
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 last() {
-	branch=`git symbolic-ref refs/remotes/origin/HEAD`
-	git log --pretty=%H $branch | head -1 | xargs git checkout 
+    REMOTE=$(git remote)
+    branch=${1:-$(git symbolic-ref "refs/remotes/$REMOTE/HEAD")}
+    git log -n 1 --pretty=%H "$branch" | git checkout 
 }
 last "$@"

--- a/git-next
+++ b/git-next
@@ -1,12 +1,13 @@
 #!/bin/sh
 
 next() {
-	branch=`git symbolic-ref refs/remotes/origin/HEAD`
+    REMOTE=$(git remote)
+	branch=$(git symbolic-ref "refs/remotes/$REMOTE/HEAD")
 	if [ -z "$1" ]; then
 		n=1
 	else
 		n=$1
 	fi
-	git log --reverse --pretty=%H $branch | grep -A $n $(git rev-parse HEAD) | tail -1 | xargs git checkout
+	git log --reverse --pretty=%H "$branch" | grep -A $n $(git rev-parse HEAD) | tail -1 | xargs git checkout
 }
 next "$@"

--- a/git-paging-alias.txt
+++ b/git-paging-alias.txt
@@ -1,0 +1,21 @@
+[alias]
+    swc-first = !"first() { \
+        REMOTE=\"$(git remote)\"; \
+        branch=\"${1:-$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")}\"; \
+        git switch --detach $(git log --reverse --pretty=%H \"$branch\" | head -1); \
+    };first"
+    swc-last = !"last(){ \
+        REMOTE=\"$(git remote)\"; \
+        branch=\"${1:-$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")}\"; \
+        git switch --detach $(git log -n 1 --pretty=%H \"$branch\"); \
+    };last"
+    swc-prev = !"prev(){ \
+        n=\"${1:-1}\"; \
+        git checkout HEAD~$n; \
+    };prev"
+    swc-next = !"next(){ \
+        REMOTE=\"$(git remote)\"; \
+        branch=\"${1:-$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")}\"; \
+        n=\"${1:-1}\"; \
+        git switch --detach $(git log --reverse --pretty=%H \"$branch\" | grep -A $n $(git rev-parse HEAD) | tail -1); \
+    };next"

--- a/git-paging-alias.txt
+++ b/git-paging-alias.txt
@@ -29,7 +29,7 @@
     };prev"
     swc-next = !"next(){ \
         REMOTE=\"$(git remote)\"; \
-        branch=\"${1:-$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")}\"; \
+        branch=\"$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")\"; \
         n=\"${1:-1}\"; \
         git switch --detach $(git log --reverse --pretty=%H \"$branch\" | grep -A $n $(git rev-parse HEAD) | tail -1); \
     };next"

--- a/git-paging-alias.txt
+++ b/git-paging-alias.txt
@@ -1,4 +1,18 @@
 [alias]
+    hist = !"hist() { \
+        if test -z $1;then \
+            REMOTE=\"$(git remote)\"; \
+            params=\"${1:-$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")}\"; \
+        else \
+            params=\"$@\"; \
+        fi; \
+        git log \
+            --color \
+            --graph \
+            --abbrev-commit \
+            --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<author:%an == commitor:%cn>%Creset' \
+            $params; \
+    };hist"
     swc-first = !"first() { \
         REMOTE=\"$(git remote)\"; \
         branch=\"${1:-$(git symbolic-ref \"refs/remotes/$REMOTE/HEAD\")}\"; \

--- a/git-prev
+++ b/git-prev
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 prev() {
-	branch=`git symbolic-ref refs/remotes/origin/HEAD`
 	if [ -z "$1" ]; then
 		n=1
 	else

--- a/install.sh
+++ b/install.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
-install -m 755 git-* /usr/local/bin
+if test -f git-paging-alias.txt;then 
+    git config --global --add include.path $(readlink -f git-paging-alias.txt)
+else
+    install -m 755 git-* /usr/local/bin
+fi


### PR DESCRIPTION
1. 修复了项目 "multi remote name - remote name is not origin" 情况下，执行命令报错
2. 新增了 git hist 查看所有 commit 简要信息
3. 新增了 git-paging-alias.txt，调整了 `install.sh`，使用 git alias 方式来统一管理别名命令
4. 更新了 README.md，增加相应命令说明

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README.md with new sections on installation instructions and Git alias guidelines
	- Improved clarity and usability of documentation

- **New Features**
	- Added new Git aliases for enhanced commit history navigation:
		- `hist`: Detailed Git log display
		- `swc-first`: Switch to first commit
		- `swc-last`: Switch to last commit
		- `swc-prev`: Navigate to previous commits
		- `swc-next`: Navigate to next commits

- **Chores**
	- Refined installation script to handle Git alias configuration
	- Improved shell script functions for more dynamic branch selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->